### PR TITLE
Add option to exit blockquote on Mod+Enter

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -1,5 +1,6 @@
 import onBackspace from './onBackspace';
 import onEnter from './onEnter';
 import onKeyDown from './onKeyDown';
+import onModEnter from './onModEnter';
 
-export { onBackspace, onEnter, onKeyDown };
+export { onBackspace, onEnter, onKeyDown, onModEnter };

--- a/lib/handlers/onKeyDown.js
+++ b/lib/handlers/onKeyDown.js
@@ -4,6 +4,7 @@ import { type Change } from '@gitbook/slate';
 import type Options from '../options';
 
 import onEnter from './onEnter';
+import onModEnter from './onModEnter';
 import onBackspace from './onBackspace';
 
 const KEY_ENTER = 'Enter';
@@ -20,9 +21,11 @@ function onKeyDown(
 ): void | any {
     // Build arguments list
     const args = [opts, event, change, editor];
-
     switch (event.key) {
         case KEY_ENTER:
+            if (event.metaKey && opts.exitBlockType) {
+                return onModEnter(...args);
+            }
             return onEnter(...args);
         case KEY_BACKSPACE:
             return onBackspace(...args);

--- a/lib/handlers/onModEnter.js
+++ b/lib/handlers/onModEnter.js
@@ -1,0 +1,37 @@
+/* @flow */
+import { type Change, Block, Text } from '@gitbook/slate';
+import { getCurrentBlockquote } from '../utils';
+import type Options from '../options';
+
+/**
+ * User pressed Mod+Enter in an editor
+ * Exit the current block and inserts a paragraph after it
+ */
+function onModEnter(
+    opts: Options,
+    event: SyntheticEvent<*>,
+    change: Change,
+): ?Change {
+    const { value } = change;
+
+    const blockquote = getCurrentBlockquote(opts, value)
+    
+    if (!blockquote) {
+        return undefined;
+    }
+    event.preventDefault();
+
+    const exitBlock = Block.create({
+        type: opts.exitBlockType,
+        nodes: [Text.create('')]
+    });
+
+    const parent = value.document.getParent(blockquote.key);
+    const index = parent.nodes.findIndex(child => child.key == blockquote.key);
+
+    return change
+        .insertNodeByKey(parent.key, index + 1, exitBlock)
+        .collapseToStartOf(exitBlock);
+}
+
+export default onModEnter;

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,7 +3,8 @@ import { Record } from 'immutable';
 
 const DEFAULTS = {
     type: 'blockquote',
-    typeDefault: 'paragraph'
+    typeDefault: 'paragraph',
+    exitBlockType: 'paragraph'
 };
 
 /**
@@ -12,11 +13,13 @@ const DEFAULTS = {
 class Options extends Record(DEFAULTS) {
     type: string;
     typeDefault: string;
+    exitBlockType: string;
 }
 
 export type OptionsFormat = {
     type?: string, // type for blockquotes
-    typeDefault?: string // type for default block in blockquote.
+    typeDefault?: string, // type for default block in blockquote.
+    exitBlockType?: string // type of block inserted when exiting
 };
 
 export default Options;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "@gitbook/slate-schema-violations": "^0.1.20"
   },
   "files": [
-     "dist",
-     "*.md"
+    "dist",
+    "*.md"
   ],
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
This PR adds onModEnter function to exit quotes with `command+enter`
The goal is to have a more consistent editing UX, because this behavior is already handled in code blocks and tables.